### PR TITLE
Support adding a custom session

### DIFF
--- a/pyhoma/client.py
+++ b/pyhoma/client.py
@@ -20,12 +20,20 @@ API_URL = "https://tahomalink.com/enduser-mobile-web/enduserAPI/"  # /doc for AP
 class TahomaClient:
     """ Interface class for the Tahoma API """
 
-    def __init__(self, username: str, password: str, api_url: str = API_URL) -> None:
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        api_url: str = API_URL,
+        session: aiohttp.ClientSession = None,
+    ) -> None:
         """
         Constructor
 
         :param username: the username for Tahomalink.com
         :param password: the password for Tahomalink.com
+        :param api_url: optional custom api url
+        :param session: optional aiohttp.ClientSession
         """
 
         self.username = username
@@ -36,7 +44,7 @@ class TahomaClient:
         self.__roles = None
         self.event_listener_id: Optional[str] = None
 
-        self.session = aiohttp.ClientSession()
+        self.session = session if session else aiohttp.ClientSession()
 
     async def __aenter__(self) -> TahomaClient:
         return self

--- a/pyhoma/client.py
+++ b/pyhoma/client.py
@@ -5,9 +5,8 @@ import urllib.parse
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Type, Union
 
-import aiohttp
 import humps
-from aiohttp import ClientResponse
+from aiohttp import ClientResponse, ClientSession
 
 from pyhoma.exceptions import BadCredentialsException, TooManyRequestsException
 from pyhoma.models import Command, Device, Event, Execution, Scenario, State
@@ -25,7 +24,7 @@ class TahomaClient:
         username: str,
         password: str,
         api_url: str = API_URL,
-        session: aiohttp.ClientSession = None,
+        session: ClientSession = None,
     ) -> None:
         """
         Constructor
@@ -33,7 +32,7 @@ class TahomaClient:
         :param username: the username for Tahomalink.com
         :param password: the password for Tahomalink.com
         :param api_url: optional custom api url
-        :param session: optional aiohttp.ClientSession
+        :param session: optional ClientSession
         """
 
         self.username = username
@@ -44,7 +43,7 @@ class TahomaClient:
         self.__roles = None
         self.event_listener_id: Optional[str] = None
 
-        self.session = session if session else aiohttp.ClientSession()
+        self.session = session if session else ClientSession()
 
     async def __aenter__(self) -> TahomaClient:
         return self


### PR DESCRIPTION
```python3
self.websession = async_create_clientsession(
	self.hass, cookie_jar=aiohttp.CookieJar(unsafe=True)
)
```

In order to achieve platinum status, HA requires to pass a Client Session to the library. I made it optional, since adding your own session won't be necessary in many cases.