### PR TITLE
Add get_device_definition to retrieve the dict of all device definition.

### DIFF
--- a/pyhoma/client.py
+++ b/pyhoma/client.py
@@ -137,7 +137,7 @@ class TahomaClient:
             f"setup/devices/{urllib.parse.quote_plus(deviceurl)}"
         )
 
-        return response['definition']
+        return response["definition"]
 
     @backoff.on_exception(
         backoff.expo, NotAuthenticatedException, max_tries=2, on_backoff=relogin

--- a/pyhoma/client.py
+++ b/pyhoma/client.py
@@ -129,7 +129,7 @@ class TahomaClient:
     @backoff.on_exception(
         backoff.expo, NotAuthenticatedException, max_tries=2, on_backoff=relogin
     )
-    async def get_device_definition(self, deviceurl: str) -> Dict:
+    async def get_device_definition(self, deviceurl: str) -> Dict[str, Any]:
         """
         Retrieve a particular setup device definition
         """

--- a/pyhoma/client.py
+++ b/pyhoma/client.py
@@ -129,7 +129,7 @@ class TahomaClient:
     @backoff.on_exception(
         backoff.expo, NotAuthenticatedException, max_tries=2, on_backoff=relogin
     )
-    async def get_device_definition(self, deviceurl: str) -> Dict[str, Any]:
+    async def get_device_definition(self, deviceurl: str) -> JSON:
         """
         Retrieve a particular setup device definition
         """

--- a/pyhoma/client.py
+++ b/pyhoma/client.py
@@ -129,7 +129,7 @@ class TahomaClient:
     @backoff.on_exception(
         backoff.expo, NotAuthenticatedException, max_tries=2, on_backoff=relogin
     )
-    async def get_device_definition(self, deviceurl: str) -> JSON:
+    async def get_device_definition(self, deviceurl: str) -> Optional[JSON]:
         """
         Retrieve a particular setup device definition
         """

--- a/pyhoma/client.py
+++ b/pyhoma/client.py
@@ -137,7 +137,7 @@ class TahomaClient:
             f"setup/devices/{urllib.parse.quote_plus(deviceurl)}"
         )
 
-        return response["definition"]
+        return response.get("definition")
 
     @backoff.on_exception(
         backoff.expo, NotAuthenticatedException, max_tries=2, on_backoff=relogin

--- a/pyhoma/client.py
+++ b/pyhoma/client.py
@@ -129,6 +129,19 @@ class TahomaClient:
     @backoff.on_exception(
         backoff.expo, NotAuthenticatedException, max_tries=2, on_backoff=relogin
     )
+    async def get_device_definition(self, deviceurl: str) -> Dict:
+        """
+        Retrieve a particular setup device definition
+        """
+        response = await self.__get(
+            f"setup/devices/{urllib.parse.quote_plus(deviceurl)}"
+        )
+
+        return response['definition']
+
+    @backoff.on_exception(
+        backoff.expo, NotAuthenticatedException, max_tries=2, on_backoff=relogin
+    )
     async def get_state(self, deviceurl: str) -> List[State]:
         """
         Retrieve states of requested device


### PR DESCRIPTION
This will allow adding a service to ha-tahoma to retrieve definitions such
as available commands, useful to discover commands to be run by the execute_command
service.