### PR TITLE
Add sub_type to models

### DIFF
--- a/pyhoma/models.py
+++ b/pyhoma/models.py
@@ -366,7 +366,7 @@ class Gateway:
         *,
         partners: Optional[List[Dict[str, Any]]] = None,
         functions: Optional[str] = None,
-        sub_type: Optional[GatewaySubType] = None,
+        sub_type: GatewaySubType,
         gateway_id: str,
         alive: bool,
         mode: str,
@@ -399,4 +399,4 @@ class Gateway:
         try:
             self.sub_type = GatewaySubType(sub_type)
         except ValueError:
-            self.sub_type = None  # type: ignore
+            self.sub_type = sub_type

--- a/pyhoma/models.py
+++ b/pyhoma/models.py
@@ -399,4 +399,4 @@ class Gateway:
         try:
             self.sub_type = GatewaySubType(sub_type)
         except ValueError:
-            pass
+            self.sub_type = None  # type: ignore


### PR DESCRIPTION
In the previous PR, I didn't add sub_type which is not a good call... It is not consistent and needs extra checking when the key doesn't exist.